### PR TITLE
Fix linking asmdef.exe on DOS with newer gcc

### DIFF
--- a/makefile.dj
+++ b/makefile.dj
@@ -384,7 +384,7 @@ obj/djgpp/asmdef.inc: obj/djgpp/asmdef.exe
 	obj/djgpp/asmdef.exe obj/djgpp/asmdef.inc
 
 obj/djgpp/asmdef.exe: src/i386/asmdef.c include/*.h include/allegro/*.h obj/djgpp/asmcapa.h
-	$(CC) -O $(WFLAGS) -I. -I./include -o obj/djgpp/asmdef.exe src/i386/asmdef.c
+	$(CC) -O $(WFLAGS) -fgnu89-inline -I. -I./include -o obj/djgpp/asmdef.exe src/i386/asmdef.c
 
 endif
 


### PR DESCRIPTION
Add `-fgnu89-inline` to Make target for `asmdef.exe`.

GCC versions 5+ default to a new C standard, which have different handling for `inline` function definitions.  The previous fix in line 189 corrects building for cross-compiling; however, those platforms use the `asmdef.sh` script to generate `asmdef.inc`.  MS-DOS hosts instead build a helper tool called `asmdef.exe`, and without this new parameter, the build process will fail with "Undefined reference to..." errors on GCC >= version 5.

Adding `-fgnu89-inline` fixes the linker errors and allows building with modern GCC versions.